### PR TITLE
Switch to ebilet.tcddtasimacilik.gov.tr endpoints

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -1,9 +1,14 @@
 import requests
-import config
 
 headers = {
-    'Authorization': 'Basic ZGl0cmF2b3llYnNwOmRpdHJhMzQhdm8u'
+    "Authorization": "Basic ZGl0cmF2b3llYnNwOmRpdHJhMzQhdm8u",
+    "Referer": "https://ebilet.tcddtasimacilik.gov.tr/sefer-listesi",
+    "User-Agent": (
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36"
+    ),
 }
+
 
 def post_request(url, body):
     return requests.post(url, json=body, headers=headers)

--- a/src/functions.py
+++ b/src/functions.py
@@ -9,8 +9,8 @@ binis_istasyon_id = stations.get(config.binis_istasyon_adi)
 inis_istasyon_id = stations.get(config.inis_istasyon_adi)
 formatted_date = format_date(config.date)
 
-sefer_url = "https://api-yebsp.tcddtasimacilik.gov.tr/sefer/seferSorgula"
-vagon_url = "https://api-yebsp.tcddtasimacilik.gov.tr/vagon/vagonHaritasindanYerSecimi"
+sefer_url = "https://ebilet.tcddtasimacilik.gov.tr/api/sefer/seferSorgula"
+vagon_url = "https://ebilet.tcddtasimacilik.gov.tr/api/vagon/vagonHaritasindanYerSecimi"
 
 # Function to fetch and filter journeys
 def fetch_and_filter_journeys():

--- a/util/fetch_stations.py
+++ b/util/fetch_stations.py
@@ -2,7 +2,7 @@ import requests
 import json
 
 # Endpoint URL
-url = "https://api-yebsp.tcddtasimacilik.gov.tr/istasyon/istasyonYukle"
+url = "https://ebilet.tcddtasimacilik.gov.tr/api/istasyon/istasyonYukle"
 
 # Request body
 body = {
@@ -14,7 +14,12 @@ body = {
 
 # Authorization header
 headers = {
-    'Authorization': 'Basic ZGl0cmF2b3llYnNwOmRpdHJhMzQhdm8u'
+    "Authorization": "Basic ZGl0cmF2b3llYnNwOmRpdHJhMzQhdm8u",
+    "Referer": "https://ebilet.tcddtasimacilik.gov.tr/sefer-listesi",
+    "User-Agent": (
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36"
+    ),
 }
 
 # Send POST request


### PR DESCRIPTION
## Summary
- point sefer and seat queries to `ebilet.tcddtasimacilik.gov.tr`
- include `Referer` and browser `User-Agent` headers required by new web endpoint
- update station fetch utility to use the new base URL

## Testing
- `python -m py_compile src/api.py src/functions.py util/fetch_stations.py`


------
https://chatgpt.com/codex/tasks/task_e_6894969571fc832cbef5443f2104790d